### PR TITLE
feat: add process search tool for LCA processes data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { regFlowSearchTool } from './tools/flow_hybrid_search.js';
+import { regProcessSearchTool } from './tools/process_hybrid_search.js';
 
 const server = new McpServer({
   name: 'TianGong-MCP-Server',
@@ -10,6 +11,7 @@ const server = new McpServer({
 });
 
 regFlowSearchTool(server);
+regProcessSearchTool(server);
 
 async function runServer() {
   const transport = new StdioServerTransport();

--- a/src/tools/process_hybrid_search.ts
+++ b/src/tools/process_hybrid_search.ts
@@ -1,0 +1,53 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import cleanObject from './_shared/clean_object.js';
+import { base_url, supabase_anon_key, x_api_key, x_region } from './_shared/config.js';
+
+const input_schema = {
+  query: z.string().min(1).describe('Queries from user'),
+};
+
+async function searchProcesses({ query }: { query: string }): Promise<string> {
+  const url = `${base_url}/process_hybrid_search`;
+  // console.error('URL:', url);
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${supabase_anon_key}`,
+        'x-api-key': x_api_key,
+        'x-region': x_region,
+      },
+      body: JSON.stringify(
+        cleanObject({
+          query,
+        }),
+      ),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error: ${response.status} ${response.statusText}`);
+    }
+    const data = await response.json();
+    return JSON.stringify(data);
+  } catch (error) {
+    console.error('Error making the request:', error);
+    throw error;
+  }
+}
+
+export function regProcessSearchTool(server: McpServer) {
+  server.tool('Search_processes_Tool', 'Search LCA processes data.', input_schema, async ({ query }) => {
+    const result = await searchProcesses({
+      query,
+    });
+    return {
+      content: [
+        {
+          type: 'text',
+          text: result,
+        },
+      ],
+    };
+  });
+}


### PR DESCRIPTION
@linancn This pull request introduces a new tool, `regProcessSearchTool`, to the MCP server, enabling process hybrid search functionality. It includes the necessary registration in the main server file and the implementation of the tool itself in a new file. Below are the most important changes grouped by theme:

### New Tool Implementation:

* **`src/tools/process_hybrid_search.ts`:** Added the `regProcessSearchTool` function, which registers a new tool named `Search_processes_Tool` to perform process hybrid searches. This includes defining an input schema using `zod`, implementing the `searchProcesses` function to interact with an external API, and handling responses and errors.

### Server Integration:

* **`src/index.ts`:** Updated the server setup to include the registration of the new `regProcessSearchTool` function, enabling the tool to be part of the MCP server's functionality.