### PR TITLE
docs: add AI doc contracts for issue #14

### DIFF
--- a/.github/scripts/ai-doc-lint.mjs
+++ b/.github/scripts/ai-doc-lint.mjs
@@ -1,0 +1,426 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const MARKDOWN_METADATA_KEYS = [
+  'docType',
+  'scope',
+  'status',
+  'authoritative',
+  'owner',
+  'language',
+  'whenToUse',
+  'whenToUpdate',
+  'checkPaths',
+  'lastReviewedAt',
+  'lastReviewedCommit',
+];
+
+const YAML_METADATA_KEYS = ['lastReviewedAt', 'lastReviewedCommit'];
+
+export function normalizePath(value) {
+  return value.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+/g, '/');
+}
+
+export function escapeRegex(value) {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+export function globToRegExp(pattern) {
+  const normalized = normalizePath(pattern);
+  let output = '^';
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*') {
+      if (next === '*') {
+        output += '.*';
+        index += 1;
+      } else {
+        output += '[^/]*';
+      }
+      continue;
+    }
+
+    if (char === '?') {
+      output += '[^/]';
+      continue;
+    }
+
+    output += escapeRegex(char);
+  }
+
+  output += '$';
+  return new RegExp(output);
+}
+
+export function matchesPattern(filePath, pattern) {
+  return globToRegExp(pattern).test(normalizePath(filePath));
+}
+
+export function parseJsonCompatibleYaml(text, sourceLabel) {
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(
+      `${sourceLabel} is not valid JSON-compatible YAML. Phase 1 contract files must use JSON-compatible YAML syntax. ${error.message}`,
+    );
+  }
+}
+
+export function loadJsonCompatibleYaml(absPath, sourceLabel = absPath) {
+  return parseJsonCompatibleYaml(readFileSync(absPath, 'utf8'), sourceLabel);
+}
+
+export function parseFrontmatterKeys(text) {
+  const match = text.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!match) {
+    return new Set();
+  }
+
+  return new Set(
+    Array.from(match[1].matchAll(/^([A-Za-z][A-Za-z0-9]*)\s*:/gm), (result) => result[1]),
+  );
+}
+
+export function missingMarkdownMetadata(text) {
+  const keys = parseFrontmatterKeys(text);
+  return MARKDOWN_METADATA_KEYS.filter((key) => !keys.has(key));
+}
+
+export function missingYamlMetadata(text, sourceLabel) {
+  const parsed = parseJsonCompatibleYaml(text, sourceLabel);
+  return YAML_METADATA_KEYS.filter((key) => !(key in parsed));
+}
+
+export function isKeyMarkdownDoc(relPath) {
+  const normalized = normalizePath(relPath);
+  return (
+    path.posix.basename(normalized) === 'AGENTS.md' ||
+    ((normalized.startsWith('ai/') || normalized.includes('/ai/')) && normalized.endsWith('.md'))
+  );
+}
+
+export function isKeyYamlContract(relPath) {
+  const normalized = normalizePath(relPath);
+  return normalized.endsWith('.yaml') && (normalized.startsWith('ai/') || normalized.includes('/ai/'));
+}
+
+export function detectImpactLayout(rootDir) {
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact-map.yaml'))) {
+    return 'workspace';
+  }
+  if (existsSync(path.join(rootDir, 'ai', 'doc-impact.yaml'))) {
+    return 'repo';
+  }
+  return 'none';
+}
+
+export function listImpactFiles(rootDir) {
+  const layout = detectImpactLayout(rootDir);
+
+  if (layout === 'repo') {
+    return [
+      {
+        absPath: path.join(rootDir, 'ai', 'doc-impact.yaml'),
+        relPath: 'ai/doc-impact.yaml',
+        baseDir: '',
+      },
+    ];
+  }
+
+  if (layout !== 'workspace') {
+    return [];
+  }
+
+  const rootImpact = path.join(rootDir, 'ai', 'doc-impact-map.yaml');
+  const results = [
+    {
+      absPath: rootImpact,
+      relPath: 'ai/doc-impact-map.yaml',
+      baseDir: '',
+    },
+  ];
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    if (entry.name.startsWith('.')) {
+      continue;
+    }
+
+    const repoImpact = path.join(rootDir, entry.name, 'ai', 'doc-impact.yaml');
+    if (!existsSync(repoImpact)) {
+      continue;
+    }
+
+    results.push({
+      absPath: repoImpact,
+      relPath: normalizePath(path.join(entry.name, 'ai', 'doc-impact.yaml')),
+      baseDir: entry.name,
+    });
+  }
+
+  return results;
+}
+
+export function loadImpactFiles(rootDir) {
+  return listImpactFiles(rootDir).flatMap(({ absPath, relPath, baseDir }) => {
+    const parsed = loadJsonCompatibleYaml(absPath, relPath);
+    const rules = Array.isArray(parsed.rules) ? parsed.rules : [];
+
+    return rules.map((rule) => ({
+      source: relPath,
+      baseDir,
+      rule,
+    }));
+  });
+}
+
+export function resolveRulePath(baseDir, relPattern) {
+  if (!baseDir) {
+    return normalizePath(relPattern);
+  }
+  return normalizePath(path.posix.join(baseDir, relPattern));
+}
+
+export function matchRules(changedPaths, loadedRules) {
+  const matches = [];
+
+  for (const changedPath of changedPaths) {
+    for (const loaded of loadedRules) {
+      const triggers = Array.isArray(loaded.rule.triggers) ? loaded.rule.triggers : [];
+      if (
+        triggers.some((trigger) =>
+          matchesPattern(changedPath, resolveRulePath(loaded.baseDir, trigger.path)),
+        )
+      ) {
+        matches.push({
+          changedPath,
+          source: loaded.source,
+          rule: loaded.rule,
+          baseDir: loaded.baseDir,
+        });
+      }
+    }
+  }
+
+  return matches;
+}
+
+export function collectExpectedDocs(matches) {
+  const expected = new Map();
+
+  for (const match of matches) {
+    const requiredDocs = Array.isArray(match.rule.requiredDocs) ? match.rule.requiredDocs : [];
+    for (const doc of requiredDocs) {
+      const fullPath = resolveRulePath(match.baseDir, doc.path);
+      if (!expected.has(fullPath)) {
+        expected.set(fullPath, {
+          path: fullPath,
+          rules: new Set(),
+          changedPaths: new Set(),
+          modes: new Set(),
+        });
+      }
+
+      const entry = expected.get(fullPath);
+      entry.rules.add(match.rule.id);
+      entry.changedPaths.add(match.changedPath);
+      entry.modes.add(doc.mode);
+    }
+  }
+
+  return expected;
+}
+
+export function parseArgs(argv) {
+  const options = {
+    rootDir: process.cwd(),
+    mode: 'warn',
+    files: [],
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--root') {
+      options.rootDir = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--mode') {
+      options.mode = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--base') {
+      options.base = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--head') {
+      options.head = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg === '--files') {
+      options.files = argv[index + 1]
+        .split(',')
+        .map((value) => normalizePath(value.trim()))
+        .filter(Boolean);
+      index += 1;
+      continue;
+    }
+    if (arg === '--help') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+export function getChangedPaths({ rootDir, base, head, files }) {
+  if (files.length > 0) {
+    return [...new Set(files)];
+  }
+
+  if (!base || !head) {
+    throw new Error('Pass either --files or both --base and --head.');
+  }
+
+  const output = execFileSync('git', ['diff', '--name-only', `${base}...${head}`], {
+    cwd: rootDir,
+    encoding: 'utf8',
+  });
+
+  return [...new Set(output.split(/\r?\n/).map((value) => normalizePath(value.trim())).filter(Boolean))];
+}
+
+export function buildDocProblems({ rootDir, changedPaths }) {
+  const problems = [];
+
+  for (const relPath of changedPaths) {
+    const absPath = path.join(rootDir, relPath);
+    if (!existsSync(absPath)) {
+      continue;
+    }
+
+    if (isKeyMarkdownDoc(relPath)) {
+      const missing = missingMarkdownMetadata(readFileSync(absPath, 'utf8'));
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing Markdown metadata keys: ${missing.join(', ')}`,
+        });
+      }
+      continue;
+    }
+
+    if (isKeyYamlContract(relPath)) {
+      const missing = missingYamlMetadata(readFileSync(absPath, 'utf8'), relPath);
+      if (missing.length > 0) {
+        problems.push({
+          type: 'missing-metadata',
+          path: relPath,
+          message: `Missing YAML metadata keys: ${missing.join(', ')}`,
+        });
+      }
+    }
+  }
+
+  return problems;
+}
+
+export function buildMissingDocProblems({ changedPaths, expectedDocs }) {
+  const changed = new Set(changedPaths);
+  const problems = [];
+
+  for (const entry of expectedDocs.values()) {
+    if (changed.has(entry.path)) {
+      continue;
+    }
+
+    problems.push({
+      type: 'missing-review',
+      path: entry.path,
+      message: `Expected reviewed doc was not touched. Triggered by ${Array.from(entry.changedPaths).join(', ')} via rule(s): ${Array.from(entry.rules).join(', ')}`,
+    });
+  }
+
+  return problems;
+}
+
+export function formatProblem(problem) {
+  return `- [${problem.type}] ${problem.path}: ${problem.message}`;
+}
+
+export function emitProblems(problems, mode) {
+  if (problems.length === 0) {
+    console.log('AI doc lint: no problems found.');
+    return;
+  }
+
+  const heading =
+    mode === 'enforce' ? 'AI doc lint found blocking problems:' : 'AI doc lint found warnings:';
+  const annotationLevel = mode === 'enforce' ? 'error' : 'warning';
+  console.log(heading);
+  for (const problem of problems) {
+    console.log(formatProblem(problem));
+    if (process.env.GITHUB_ACTIONS) {
+      console.log(`::${annotationLevel} file=${problem.path}::${problem.message}`);
+    }
+  }
+}
+
+export function run(options) {
+  const changedPaths = getChangedPaths(options);
+  if (changedPaths.length === 0) {
+    console.log('AI doc lint: no changed paths to inspect.');
+    return { problems: [], changedPaths, matchedRules: [] };
+  }
+
+  const loadedRules = loadImpactFiles(options.rootDir);
+  const matchedRules = matchRules(changedPaths, loadedRules);
+  const expectedDocs = collectExpectedDocs(matchedRules);
+  const problems = [
+    ...buildMissingDocProblems({ changedPaths, expectedDocs }),
+    ...buildDocProblems({ rootDir: options.rootDir, changedPaths }),
+  ];
+
+  emitProblems(problems, options.mode);
+
+  if (options.mode === 'enforce' && problems.length > 0) {
+    process.exitCode = 1;
+  }
+
+  return { problems, changedPaths, matchedRules };
+}
+
+function printHelp() {
+  console.log(`Usage: node .github/scripts/ai-doc-lint.mjs [--mode warn|enforce] [--base <sha> --head <sha> | --files <csv>] [--root <dir>]`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    if (options.help) {
+      printHelp();
+      process.exit(0);
+    }
+    run(options);
+  } catch (error) {
+    console.error(`AI doc lint error: ${error.message}`);
+    process.exit(2);
+  }
+}

--- a/.github/scripts/ai-doc-lint.test.mjs
+++ b/.github/scripts/ai-doc-lint.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  collectExpectedDocs,
+  detectImpactLayout,
+  globToRegExp,
+  isKeyMarkdownDoc,
+  loadImpactFiles,
+  matchRules,
+  missingMarkdownMetadata,
+  missingYamlMetadata,
+  normalizePath,
+} from './ai-doc-lint.mjs';
+
+test('normalizePath and globToRegExp support repo-relative matching', () => {
+  assert.equal(normalizePath('.\\tiangong-lca-next\\config\\routes.ts'), 'tiangong-lca-next/config/routes.ts');
+  assert.equal(globToRegExp('tiangong-lca-next/**').test('tiangong-lca-next/config/routes.ts'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/quality-rubric.md'), true);
+  assert.equal(globToRegExp('ai/*.md').test('ai/nested/file.md'), false);
+});
+
+test('detectImpactLayout distinguishes workspace and repo roots', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-layout-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  assert.equal(detectImpactLayout(tempDir), 'none');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'repo');
+
+  writeFileSync(path.join(tempDir, 'ai', 'doc-impact-map.yaml'), JSON.stringify({ version: 1 }));
+  assert.equal(detectImpactLayout(tempDir), 'workspace');
+});
+
+test('isKeyMarkdownDoc excludes YAML contract files', () => {
+  assert.equal(isKeyMarkdownDoc('ai/quality-rubric.md'), true);
+  assert.equal(isKeyMarkdownDoc('AGENTS.md'), true);
+  assert.equal(isKeyMarkdownDoc('ai/workspace.yaml'), false);
+});
+
+test('missingMarkdownMetadata detects absent frontmatter keys', () => {
+  const text = `---
+title: Example
+docType: contract
+scope: workspace
+status: draft
+authoritative: false
+owner: lca-workspace
+language: en
+whenToUse:
+  - x
+whenToUpdate:
+  - y
+checkPaths:
+  - ai/**
+lastReviewedAt: 2026-04-18
+---
+
+# Example
+`;
+
+  assert.deepEqual(missingMarkdownMetadata(text), ['lastReviewedCommit']);
+});
+
+test('missingYamlMetadata detects absent top-level review fields', () => {
+  const text = JSON.stringify({ version: 1, lastReviewedAt: '2026-04-18' });
+  assert.deepEqual(missingYamlMetadata(text, 'ai/example.yaml'), ['lastReviewedCommit']);
+});
+
+test('loadImpactFiles, matchRules, and collectExpectedDocs resolve repo-local paths', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+  mkdirSync(path.join(tempDir, 'subrepo', 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact-map.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'root-rule',
+            scope: 'workspace',
+            repo: 'lca-workspace',
+            triggers: [{ path: 'AGENTS.md', kind: 'doc-contract' }],
+            requiredDocs: [{ path: 'ai/workspace.yaml', mode: 'review_or_update' }],
+            reason: 'root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  writeFileSync(
+    path.join(tempDir, 'subrepo', 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'subrepo',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/task-router.md', mode: 'review_or_update' }],
+            reason: 'repo',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['AGENTS.md', 'subrepo/src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 2);
+  assert.equal(matches.length, 2);
+  assert.deepEqual([...expectedDocs.keys()].sort(), ['ai/workspace.yaml', 'subrepo/ai/task-router.md']);
+});
+
+test('loadImpactFiles supports repo-root mode', () => {
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'ai-doc-lint-repo-'));
+  mkdirSync(path.join(tempDir, 'ai'), { recursive: true });
+
+  writeFileSync(
+    path.join(tempDir, 'ai', 'doc-impact.yaml'),
+    JSON.stringify(
+      {
+        version: 1,
+        lastReviewedAt: '2026-04-18',
+        lastReviewedCommit: 'abc',
+        rules: [
+          {
+            id: 'repo-rule',
+            scope: 'repo',
+            repo: 'example',
+            triggers: [{ path: 'src/**', kind: 'code' }],
+            requiredDocs: [{ path: 'ai/validation.md', mode: 'review_or_update' }],
+            reason: 'repo-root',
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const loadedRules = loadImpactFiles(tempDir);
+  const matches = matchRules(['src/index.ts'], loadedRules);
+  const expectedDocs = collectExpectedDocs(matches);
+
+  assert.equal(loadedRules.length, 1);
+  assert.equal(matches.length, 1);
+  assert.deepEqual([...expectedDocs.keys()], ['ai/validation.md']);
+});

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -1,0 +1,32 @@
+name: ai-doc-lint
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  ai-doc-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Run ai-doc-lint unit tests
+        run: node --test .github/scripts/ai-doc-lint.test.mjs
+
+      - name: Run ai-doc-lint
+        run: |
+          node .github/scripts/ai-doc-lint.mjs \
+            --mode enforce \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,113 @@
+---
+title: mcp AI Working Guide
+docType: contract
+scope: repo
+status: active
+authoritative: true
+owner: mcp
+language: en
+whenToUse:
+  - when a task may change MCP transports, auth surfaces, tool registration, OAuth demo pages, or lifecycle-model preprocessing in tiangong-lca-mcp
+  - when routing work from the workspace root into tiangong-lca-mcp
+  - when deciding whether a change belongs here, in tiangong-lca-edge-functions, in tiangong-lca-next, or in tidas-tools
+whenToUpdate:
+  - when runtime modes, auth boundaries, or tool registration change
+  - when validation or runtime prerequisites change
+  - when the repo-local AI bootstrap docs under ai/ change
+checkPaths:
+  - AGENTS.md
+  - README.md
+  - README_CN.md
+  - DEV_EN.md
+  - DEV_CN.md
+  - ai/**/*.md
+  - ai/**/*.yaml
+  - package.json
+  - .nvmrc
+  - Dockerfile
+  - .env.example
+  - mcp_config.json
+  - src/**
+  - public/**
+  - test/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414
+related:
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - README.md
+  - DEV_EN.md
+---
+
+## Repo Contract
+
+`tiangong-lca-mcp` owns TianGong LCA MCP transports and tool exposure: STDIO, authenticated Streamable HTTP, local Streamable HTTP, OAuth helpers, tool registration, and lifecycle-model preprocessing that is intentionally part of the MCP surface. Start here when the task may change how MCP clients connect or what this MCP server exposes.
+
+## AI Load Order
+
+Load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. `ai/task-router.md`
+4. `ai/validation.md`
+5. `ai/architecture.md`
+6. `README.md` or `DEV_EN.md` only for human-oriented setup details
+
+Do not start by assuming that remote search behavior or product UI truth lives in this repository.
+
+## Repo Ownership
+
+This repo owns:
+
+- MCP transports under `src/index.ts`, `src/index_server.ts`, and `src/index_server_local.ts`
+- auth middleware, config, and OAuth helpers under `src/_shared/**` and `src/auth_app.ts`
+- MCP tool registration and tool wrappers under `src/tools/**`
+- MCP prompts and resources under `src/prompts/**` and `src/resources/**`
+- static OAuth demo pages under `public/**`
+- the checked-in client example in `mcp_config.json`
+
+This repo does not own:
+
+- remote search implementation or Edge Function business logic
+- Next.js product UI behavior
+- standalone TIDAS conversion, export, or batch tooling
+- workspace integration state after merge
+
+Route those tasks to:
+
+- `tiangong-lca-edge-functions` for remote hybrid-search or API runtime behavior
+- `tiangong-lca-next` for product UI behavior
+- `tidas-tools` for standalone conversion, validation, and export tooling
+- `lca-workspace` for root integration after merge
+
+## Runtime Facts
+
+- Published binaries:
+  - `tiangong-lca-mcp-stdio`
+  - `tiangong-lca-mcp-http`
+  - `tiangong-lca-mcp-http-local`
+- The checked-in runtime prerequisites are currently inconsistent:
+  - `.nvmrc` and `Dockerfile` imply Node 24
+  - `DEV_EN.md` still says Node 22
+- `npm run lint` is mutating because it runs Prettier with `--write`
+- `npm test` is currently a demo/manual script for TIDAS validation examples, not an assertion-heavy test suite
+
+## Hard Boundaries
+
+- Do not treat the MCP repo as the source of truth for remote Edge search semantics
+- Do not move product UI or app workflow behavior into this repo
+- Do not document `npm test` as a strong automated regression suite; it is currently a manual/demo path
+- Do not treat a merged repo PR here as workspace-delivery complete if the root repo still needs a submodule bump
+
+## Workspace Integration
+
+A merged PR in `tiangong-lca-mcp` is repo-complete, not delivery-complete.
+
+If the change must ship through the workspace:
+
+1. merge the child PR into `tiangong-lca-mcp`
+2. update the `lca-workspace` submodule pointer deliberately
+3. complete any later workspace-level validation that depends on the updated MCP snapshot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Route those tasks to:
 
 ## Runtime Facts
 
+- Repo-local AI-doc maintenance is enforced by `.github/workflows/ai-doc-lint.yml` using the vendored `.github/scripts/ai-doc-lint.*` files.
 - Published binaries:
   - `tiangong-lca-mcp-stdio`
   - `tiangong-lca-mcp-http`

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -39,14 +39,11 @@ docker run -d \
 ```bash
 # 安装 Node.js
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
-nvm install 22
-nvm use
+nvm install 24
+nvm use 24
 
 # 安装依赖
-npm install
-
-# 更新依赖
-npm update && npm ci
+npm ci
 ```
 
 ### 代码格式化

--- a/DEV_EN.md
+++ b/DEV_EN.md
@@ -39,14 +39,11 @@ docker run -d \
 ```bash
 # Install Node.js
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
-nvm install 22
-nvm use
+nvm install 24
+nvm use 24
 
 # Install dependencies
-npm install
-
-# Update dependencies
-npm update && npm ci
+npm ci
 ```
 
 ### Code Formatting

--- a/ai/architecture.md
+++ b/ai/architecture.md
@@ -1,0 +1,118 @@
+---
+title: mcp Architecture Notes
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: mcp
+language: en
+whenToUse:
+  - when you need a compact mental model of the repo before editing transports, auth, or tool wrappers
+  - when deciding which runtime mode or tool family owns a behavior change
+  - when auth, OAuth, search-wrapper, or OpenLCA hotspots are mentioned without exact paths
+whenToUpdate:
+  - when major runtime modes or tool families change
+  - when auth flow or external dependency boundaries move
+  - when the current map becomes misleading
+checkPaths:
+  - ai/architecture.md
+  - ai/repo.yaml
+  - package.json
+  - src/**
+  - public/**
+  - test/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./validation.md
+  - ../README.md
+  - ../DEV_EN.md
+---
+
+## Runtime Mode Matrix
+
+| Mode | Entry file | Main surface | Tool families exposed |
+| --- | --- | --- | --- |
+| STDIO | `src/index.ts` | `StdioServerTransport` | search wrappers, OpenLCA tools, prompts, resources, guidance |
+| HTTP | `src/index_server.ts` | authenticated Streamable HTTP on `POST /mcp` plus `/health` and `/oauth` | search wrappers and `Database_CRUD_Tool` |
+| HTTP local | `src/index_server_local.ts` | local Streamable HTTP on `POST /mcp` plus `/health` | OpenLCA tools, TIDAS validation, prompts, resources |
+
+## Auth Decision Tree
+
+The authenticated HTTP path classifies bearer tokens inside `src/_shared/auth_middleware.ts`.
+
+Accepted shapes today:
+
+1. Cognito access token
+2. base64 JSON API key payload with `{ email, password }`
+3. Supabase access token
+
+Important supporting files:
+
+- `src/_shared/cognito_auth.ts`
+- `src/_shared/decode_api_key.ts`
+- `src/_shared/supabase_session.ts`
+- `src/_shared/config.ts`
+
+API-key auth signs into Supabase and can reuse cached sessions through Upstash Redis.
+
+## OAuth Surface
+
+The MCP OAuth router lives in `src/auth_app.ts`.
+
+The authenticated HTTP server mounts:
+
+- `/oauth`
+- `/oauth/index`
+- `/oauth/demo`
+
+Static assets for that flow live in `public/**`.
+
+## Tool Families
+
+### Remote search wrappers
+
+These wrappers forward bearer auth and region headers to remote Edge Functions:
+
+- `src/tools/flow_hybrid_search.ts`
+- `src/tools/process_hybrid_search.ts`
+- `src/tools/life_cycle_model_hybrid_search.ts`
+
+They are wrappers, not the underlying search implementation.
+
+### CRUD and lifecyclemodel preprocessing
+
+The MCP-side write and preprocessing logic clusters around:
+
+- `src/tools/db_crud.ts`
+- `src/tools/life_cycle_model_file_tools.ts`
+
+This path derives `json_tg` and `rule_verification` for lifecycle model writes.
+
+### Local OpenLCA and TIDAS validation
+
+This cluster lives in:
+
+- `src/tools/openlca_ipc_lcia.ts`
+- `src/tools/openlca_ipc_lcia_methods_list.ts`
+- `src/tools/openlca_ipc_system_processes_list.ts`
+- `src/tools/tidas_data_validation.ts`
+
+The active local OpenLCA integration uses `olca-ipc`. The `openlca_grpc.ts` file is scaffold only.
+
+## External Dependency Boundaries
+
+- `edge-functions` owns remote hybrid-search and API runtime behavior
+- `next` owns product UI behavior
+- `tidas-tools` owns standalone conversion, export, and batch validation tooling
+- this repo owns MCP transports, auth classification, and tool exposure
+
+## Common Misreads
+
+- this repo is not the source of truth for remote search algorithms
+- the OAuth demo pages here are not the product app
+- `npm test` is not a strong automated regression suite
+- a merged child PR does not finish workspace delivery

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -168,6 +168,44 @@
         }
       ],
       "reason": "Tool wrapper and content changes alter what the MCP server exposes and how future work should be routed and checked."
+    },
+    {
+      "id": "mcp-ai-doc-maintenance-contract",
+      "scope": "repo",
+      "repo": "mcp",
+      "triggers": [
+        {
+          "path": ".github/workflows/ai-doc-lint.yml",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.mjs",
+          "kind": "automation"
+        },
+        {
+          "path": ".github/scripts/ai-doc-lint.test.mjs",
+          "kind": "automation"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/doc-impact.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Repo-local AI doc maintenance automation changes alter the maintenance gate and should refresh the AI contract docs."
     }
   ]
 }

--- a/ai/doc-impact.yaml
+++ b/ai/doc-impact.yaml
@@ -1,0 +1,173 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414",
+  "rules": [
+    {
+      "id": "mcp-bootstrap-contract",
+      "scope": "repo",
+      "repo": "mcp",
+      "triggers": [
+        {
+          "path": "AGENTS.md",
+          "kind": "doc-contract"
+        },
+        {
+          "path": "README.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "README_CN.md",
+          "kind": "doc-entry"
+        },
+        {
+          "path": "DEV_EN.md",
+          "kind": "doc-maintainer"
+        },
+        {
+          "path": "DEV_CN.md",
+          "kind": "doc-maintainer"
+        },
+        {
+          "path": "ai/**",
+          "kind": "doc-ai-layer"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Entry guidance, repo facts, and routing docs must stay aligned."
+    },
+    {
+      "id": "mcp-transport-and-auth-contract",
+      "scope": "repo",
+      "repo": "mcp",
+      "triggers": [
+        {
+          "path": "package.json",
+          "kind": "runtime-config"
+        },
+        {
+          "path": ".nvmrc",
+          "kind": "runtime-config"
+        },
+        {
+          "path": "Dockerfile",
+          "kind": "runtime-config"
+        },
+        {
+          "path": ".env.example",
+          "kind": "runtime-config"
+        },
+        {
+          "path": "mcp_config.json",
+          "kind": "client-config"
+        },
+        {
+          "path": "src/index.ts",
+          "kind": "transport"
+        },
+        {
+          "path": "src/index_server.ts",
+          "kind": "transport"
+        },
+        {
+          "path": "src/index_server_local.ts",
+          "kind": "transport"
+        },
+        {
+          "path": "src/auth_app.ts",
+          "kind": "oauth"
+        },
+        {
+          "path": "src/_shared/**",
+          "kind": "shared-runtime"
+        },
+        {
+          "path": "public/**",
+          "kind": "static-surface"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Transport, auth, and runtime prerequisite changes alter the executable MCP contract and should refresh the AI bootstrap docs."
+    },
+    {
+      "id": "mcp-tool-contract",
+      "scope": "repo",
+      "repo": "mcp",
+      "triggers": [
+        {
+          "path": "src/tools/**",
+          "kind": "tool-wrapper"
+        },
+        {
+          "path": "src/prompts/**",
+          "kind": "prompt"
+        },
+        {
+          "path": "src/resources/**",
+          "kind": "resource"
+        },
+        {
+          "path": "test/**",
+          "kind": "demo-test"
+        }
+      ],
+      "requiredDocs": [
+        {
+          "path": "AGENTS.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/repo.yaml",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/task-router.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/validation.md",
+          "mode": "review_or_update"
+        },
+        {
+          "path": "ai/architecture.md",
+          "mode": "review_or_update"
+        }
+      ],
+      "reason": "Tool wrapper and content changes alter what the MCP server exposes and how future work should be routed and checked."
+    }
+  ]
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -31,7 +31,6 @@
         "tiangong-lca-mcp-http-local"
       ],
       "preferredNodeSignal": ".nvmrc=24 and Dockerfile=node:24-alpine",
-      "documentedDrift": "DEV_EN.md still says nvm install 22.",
       "baselineValidationCommands": [
         "npm run build",
         "npm run lint",

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -1,0 +1,174 @@
+{
+  "version": 1,
+  "lastReviewedAt": "2026-04-18",
+  "lastReviewedCommit": "ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414",
+  "repo": {
+    "id": "mcp",
+    "path": "tiangong-lca-mcp",
+    "canonicalRepo": "linancn/tiangong-lca-mcp",
+    "purpose": "TianGong LCA MCP transport and tool-integration repository.",
+    "entryDoc": "AGENTS.md",
+    "taskRouterDoc": "ai/task-router.md",
+    "validationDoc": "ai/validation.md",
+    "architectureDoc": "ai/architecture.md",
+    "readmeDoc": "README.md",
+    "defaultBranch": "main",
+    "dailyTrunk": "main",
+    "routinePrBase": "main",
+    "branchModel": "M1",
+    "workspaceIntegrationRequired": true,
+    "rootIntegrationRule": "lca-workspace/main may bump merged main-branch MCP snapshots when the workspace intends to ship the updated MCP server surface.",
+    "trackedBy": {
+      "workspaceParentIssue": "https://github.com/tiangong-lca/workspace/issues/73",
+      "repoIssue": "https://github.com/linancn/tiangong-lca-mcp/issues/14"
+    },
+    "runtime": {
+      "packageManager": "npm",
+      "moduleSystem": "ESM",
+      "publishedBinaries": [
+        "tiangong-lca-mcp-stdio",
+        "tiangong-lca-mcp-http",
+        "tiangong-lca-mcp-http-local"
+      ],
+      "preferredNodeSignal": ".nvmrc=24 and Dockerfile=node:24-alpine",
+      "documentedDrift": "DEV_EN.md still says nvm install 22.",
+      "baselineValidationCommands": [
+        "npm run build",
+        "npm run lint",
+        "npm test"
+      ],
+      "manualProbeCommands": [
+        "npm start",
+        "npm run start:server",
+        "npm run start:server-local",
+        "npx tsx src/tools/openlca_ipc_test.ts"
+      ],
+      "knownValidationCaveats": [
+        "npm run lint rewrites files because it runs prettier -c --write.",
+        "npm test runs a sample TIDAS validation script and is not a strong assertion suite.",
+        "start:server and start:server-local use concurrently, but concurrently is not declared in package.json."
+      ]
+    },
+    "sourceOfTruth": {
+      "stableManualEditPaths": [
+        {
+          "path": "src/index.ts",
+          "role": "STDIO MCP transport entrypoint"
+        },
+        {
+          "path": "src/index_server.ts",
+          "role": "authenticated Streamable HTTP entrypoint plus OAuth page mounting"
+        },
+        {
+          "path": "src/index_server_local.ts",
+          "role": "local Streamable HTTP entrypoint without auth"
+        },
+        {
+          "path": "src/auth_app.ts",
+          "role": "OAuth routes and PKCE token exchange flow"
+        },
+        {
+          "path": "src/_shared/**",
+          "role": "auth middleware, config, transport helpers, and shared runtime pieces"
+        },
+        {
+          "path": "src/tools/**",
+          "role": "MCP tool wrappers and lifecycle-model preprocessing logic"
+        },
+        {
+          "path": "src/prompts/**",
+          "role": "MCP prompt content"
+        },
+        {
+          "path": "src/resources/**",
+          "role": "MCP resource content"
+        },
+        {
+          "path": "public/**",
+          "role": "static OAuth demo and index pages"
+        },
+        {
+          "path": "mcp_config.json",
+          "role": "checked-in example MCP client configuration"
+        }
+      ],
+      "nonOwnerBoundaries": [
+        {
+          "repo": "edge-functions",
+          "doesNotOwn": [
+            "remote hybrid-search implementation",
+            "remote Edge runtime business logic"
+          ]
+        },
+        {
+          "repo": "next",
+          "doesNotOwn": [
+            "product UI behavior",
+            "Next.js application workflows"
+          ]
+        },
+        {
+          "repo": "tidas-tools",
+          "doesNotOwn": [
+            "standalone conversion CLI",
+            "standalone export CLI",
+            "batch validation tooling"
+          ]
+        },
+        {
+          "repo": "lca-workspace",
+          "doesNotOwn": [
+            "root integration state",
+            "submodule pointer updates"
+          ]
+        }
+      ]
+    },
+    "taskHotspots": [
+      {
+        "topic": "transport mode wiring and auth boundaries",
+        "paths": [
+          "src/index.ts",
+          "src/index_server.ts",
+          "src/index_server_local.ts",
+          "src/auth_app.ts",
+          "src/_shared/auth_middleware.ts",
+          "src/_shared/config.ts",
+          "src/_shared/cognito_auth.ts",
+          "src/_shared/decode_api_key.ts",
+          "src/_shared/supabase_session.ts"
+        ]
+      },
+      {
+        "topic": "search wrappers and remote tool contracts",
+        "paths": [
+          "src/tools/flow_hybrid_search.ts",
+          "src/tools/process_hybrid_search.ts",
+          "src/tools/life_cycle_model_hybrid_search.ts",
+          "src/tools/db_crud.ts"
+        ]
+      },
+      {
+        "topic": "local OpenLCA and TIDAS validation surfaces",
+        "paths": [
+          "src/tools/openlca_ipc_*.ts",
+          "src/tools/tidas_data_validation.ts",
+          "src/tools/life_cycle_model_file_tools.ts",
+          "test/**"
+        ]
+      }
+    ],
+    "validation": {
+      "baselineLocalCommands": [
+        "npm run build",
+        "npm run lint",
+        "npm test"
+      ],
+      "notes": [
+        "Treat npm test as demo/manual proof, not as a strong regression suite.",
+        "Use npx tsx src/tools/openlca_ipc_test.ts only when the task explicitly includes a local OpenLCA smoke check.",
+        "AI-doc changes should still run the root warning-only ai-doc-lint."
+      ]
+    }
+  }
+}

--- a/ai/repo.yaml
+++ b/ai/repo.yaml
@@ -167,7 +167,7 @@
       "notes": [
         "Treat npm test as demo/manual proof, not as a strong regression suite.",
         "Use npx tsx src/tools/openlca_ipc_test.ts only when the task explicitly includes a local OpenLCA smoke check.",
-        "AI-doc changes should still run the root warning-only ai-doc-lint."
+        "AI-doc changes should still run the repo-local ai-doc-lint workflow or the equivalent local node command."
       ]
     }
   }

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -1,0 +1,92 @@
+---
+title: mcp Task Router
+docType: router
+scope: repo
+status: active
+authoritative: false
+owner: mcp
+language: en
+whenToUse:
+  - when you already know the task belongs in tiangong-lca-mcp but need the right next file or next doc
+  - when deciding whether a change belongs in one transport mode, auth wiring, one tool wrapper, or another repo
+  - when routing between MCP wrapper work and handoffs to edge-functions, next, or tidas-tools
+whenToUpdate:
+  - when new transport modes or major tool families appear
+  - when cross-repo boundaries change
+  - when validation routing becomes misleading
+checkPaths:
+  - AGENTS.md
+  - ai/repo.yaml
+  - ai/task-router.md
+  - ai/validation.md
+  - ai/architecture.md
+  - package.json
+  - src/**
+  - public/**
+  - test/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./validation.md
+  - ./architecture.md
+  - ../README.md
+  - ../DEV_EN.md
+---
+
+## Repo Load Order
+
+When working inside `tiangong-lca-mcp`, load docs in this order:
+
+1. `AGENTS.md`
+2. `ai/repo.yaml`
+3. this file
+4. `ai/validation.md` or `ai/architecture.md`
+5. `README.md` or `DEV_EN.md` only for setup details
+
+## High-Frequency Task Routing
+
+| Task intent | First code paths to inspect | Next docs to load | Notes |
+| --- | --- | --- | --- |
+| Change STDIO transport behavior | `src/index.ts`, `src/_shared/init_server.ts` | `ai/validation.md`, `ai/architecture.md` | STDIO registers search tools, OpenLCA tools, prompts, resources, and guidance. |
+| Change authenticated Streamable HTTP behavior | `src/index_server.ts`, `src/_shared/init_server_http.ts`, `src/auth_app.ts` | `ai/validation.md`, `ai/architecture.md` | This path owns `/mcp`, `/health`, `/oauth`, and the static OAuth pages. |
+| Change local Streamable HTTP behavior | `src/index_server_local.ts`, `src/_shared/init_server_http_local.ts` | `ai/validation.md`, `ai/architecture.md` | This mode is intentionally local-only and auth-free. |
+| Change bearer auth classification or session reuse | `src/_shared/auth_middleware.ts`, `src/_shared/cognito_auth.ts`, `src/_shared/decode_api_key.ts`, `src/_shared/supabase_session.ts`, `src/_shared/config.ts` | `ai/validation.md`, `ai/architecture.md` | JWT, base64 JSON API key, and Supabase token handling all live here. |
+| Change static OAuth demo or index pages | `public/**`, then `src/index_server.ts` and `src/auth_app.ts` | `ai/validation.md`, `ai/architecture.md` | This repo owns only the MCP-side OAuth pages, not the product UI. |
+| Change hybrid-search MCP wrappers | `src/tools/flow_hybrid_search.ts`, `src/tools/process_hybrid_search.ts`, `src/tools/life_cycle_model_hybrid_search.ts` | `ai/architecture.md`, `ai/validation.md` | Wrapper behavior lives here, but the remote search implementation lives in `edge-functions`. |
+| Change DB CRUD MCP behavior or lifecyclemodel write preprocessing | `src/tools/db_crud.ts`, `src/tools/life_cycle_model_file_tools.ts` | `ai/validation.md`, `ai/architecture.md` | This repo owns the MCP wrapper and preprocessing path, not the entire product UI workflow. |
+| Change TIDAS validation exposed through MCP | `src/tools/tidas_data_validation.ts` | `ai/validation.md`, `ai/architecture.md` | This repo uses `@tiangong-lca/tidas-sdk`, not `tidas-tools`, for its in-process validation surface. |
+| Change local OpenLCA helpers | `src/tools/openlca_ipc_*.ts` | `ai/validation.md`, `ai/architecture.md` | The gRPC file is scaffold only; the active runtime path is `olca-ipc`. |
+| Change actual remote search semantics or Edge response behavior | `tiangong-lca-edge-functions`, not this repo | root `ai/task-router.md` | This repo wraps those routes; it does not own their business logic. |
+| Change standalone TIDAS conversion/export/CLI tooling | `tidas-tools`, not this repo | root `ai/task-router.md` | Keep batch tooling out of the MCP repo. |
+| Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
+
+## Wrong Turns To Avoid
+
+### Fixing remote search truth only in the MCP wrapper
+
+If the actual search algorithm or Edge response changed, route the runtime fix to `tiangong-lca-edge-functions`.
+
+### Treating public OAuth demo pages as product UI ownership
+
+`public/**` here belongs to the MCP server. Product UI still belongs elsewhere.
+
+### Assuming npm test is a strong automated gate
+
+`npm test` currently runs a demo-style TIDAS validation script. Do not treat it as comprehensive regression proof.
+
+## Cross-Repo Handoffs
+
+Use these handoffs when work crosses boundaries:
+
+1. search wrapper needs remote behavior change
+   - start here for wrapper changes
+   - then coordinate with `tiangong-lca-edge-functions`
+2. lifecyclemodel or UI workflow change actually belongs to the product app
+   - route to `tiangong-lca-next`
+3. standalone TIDAS tooling change
+   - route to `tidas-tools`
+4. merged repo PR still needs to ship through the workspace
+   - return to `lca-workspace`
+   - do the submodule pointer bump there

--- a/ai/task-router.md
+++ b/ai/task-router.md
@@ -60,6 +60,7 @@ When working inside `tiangong-lca-mcp`, load docs in this order:
 | Change local OpenLCA helpers | `src/tools/openlca_ipc_*.ts` | `ai/validation.md`, `ai/architecture.md` | The gRPC file is scaffold only; the active runtime path is `olca-ipc`. |
 | Change actual remote search semantics or Edge response behavior | `tiangong-lca-edge-functions`, not this repo | root `ai/task-router.md` | This repo wraps those routes; it does not own their business logic. |
 | Change standalone TIDAS conversion/export/CLI tooling | `tidas-tools`, not this repo | root `ai/task-router.md` | Keep batch tooling out of the MCP repo. |
+| Change repo-local AI-doc maintenance only | `AGENTS.md`, `ai/**`, `.github/workflows/ai-doc-lint.yml`, `.github/scripts/ai-doc-lint.*` | `ai/validation.md` when present, otherwise `ai/repo.yaml` | Keep the repo-local maintenance gate aligned with root `ai/ci-lint-spec.md` and `ai/review-matrix.md`. |
 | Decide whether work is delivery-complete after merge | root workspace docs, not repo code paths | root `AGENTS.md`, `_docs/workspace-branch-policy-contract.md` | Root integration remains a separate phase. |
 
 ## Wrong Turns To Avoid

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -59,7 +59,7 @@ Interpret the baseline carefully:
 | auth middleware, config, or OAuth flow | `npm run build`; `npm run lint` | manually inspect or run the affected built HTTP entrypoint; record any live-token proof separately | Bearer parsing, Cognito verification, and session reuse live here. |
 | search wrappers, DB CRUD wrapper, or lifecyclemodel preprocessing | `npm run build`; `npm run lint`; `npm test` | manually inspect one representative payload path or run the relevant wrapper under an MCP client if the task explicitly includes it | If the actual remote behavior changes, record the companion repo proof separately. |
 | local OpenLCA helpers | `npm run build`; `npm run lint` | run `npx tsx src/tools/openlca_ipc_test.ts` only when the task explicitly includes a local OpenLCA smoke check | The active runtime path is `olca-ipc`, not the commented gRPC scaffold. |
-| `package.json`, `.nvmrc`, `Dockerfile`, `.env.example`, or `mcp_config.json` | `npm run build`; `npm run lint` | record the runtime prerequisite or config drift that was checked | This repo currently carries a Node-version documentation mismatch. |
+| `package.json`, `.nvmrc`, `Dockerfile`, `.env.example`, or `mcp_config.json` | `npm run build`; `npm run lint` | record the runtime prerequisite or config drift that was checked | Recheck `DEV_EN.md` and `DEV_CN.md` whenever the Node baseline or maintainer startup path changes. |
 | `public/**` only | `npm run build`; `npm run lint` | inspect the served page path if the task changes OAuth demo or index behavior | Static pages are part of the transport surface here. |
 | AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
 
@@ -67,8 +67,7 @@ Interpret the baseline carefully:
 
 Facts that matter today:
 
-- `.nvmrc` and `Dockerfile` imply Node 24
-- `DEV_EN.md` still documents Node 22
+- `.nvmrc`, `Dockerfile`, `DEV_EN.md`, and `DEV_CN.md` should stay aligned on the Node 24 baseline
 - `start:server` and `start:server-local` use `concurrently`, but `concurrently` is not declared in `package.json`
 
 If you rely on a manual workaround, record it in the PR note instead of pretending the scripted path is clean.

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -61,7 +61,7 @@ Interpret the baseline carefully:
 | local OpenLCA helpers | `npm run build`; `npm run lint` | run `npx tsx src/tools/openlca_ipc_test.ts` only when the task explicitly includes a local OpenLCA smoke check | The active runtime path is `olca-ipc`, not the commented gRPC scaffold. |
 | `package.json`, `.nvmrc`, `Dockerfile`, `.env.example`, or `mcp_config.json` | `npm run build`; `npm run lint` | record the runtime prerequisite or config drift that was checked | This repo currently carries a Node-version documentation mismatch. |
 | `public/**` only | `npm run build`; `npm run lint` | inspect the served page path if the task changes OAuth demo or index behavior | Static pages are part of the transport surface here. |
-| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+| AI docs only | run repo-local `ai-doc-lint` against touched files or the equivalent local PR check | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
 
 ## Known Caveats
 

--- a/ai/validation.md
+++ b/ai/validation.md
@@ -1,0 +1,83 @@
+---
+title: mcp Validation Guide
+docType: guide
+scope: repo
+status: active
+authoritative: false
+owner: mcp
+language: en
+whenToUse:
+  - when a tiangong-lca-mcp change is ready for local validation
+  - when deciding the minimum proof required for transport, auth, tool-wrapper, config, or docs changes
+  - when writing PR validation notes for tiangong-lca-mcp work
+whenToUpdate:
+  - when the repo gains a new canonical test wrapper or safer validation path
+  - when change categories require different proof
+  - when runtime prerequisites or validation caveats change
+checkPaths:
+  - ai/validation.md
+  - ai/task-router.md
+  - package.json
+  - .nvmrc
+  - Dockerfile
+  - .env.example
+  - mcp_config.json
+  - src/**
+  - public/**
+  - test/**
+lastReviewedAt: 2026-04-18
+lastReviewedCommit: ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414
+related:
+  - ../AGENTS.md
+  - ./repo.yaml
+  - ./task-router.md
+  - ./architecture.md
+  - ../README.md
+  - ../DEV_EN.md
+---
+
+## Default Baseline
+
+Unless the change is doc-only, the current baseline is:
+
+```bash
+npm run build
+npm run lint
+npm test
+```
+
+Interpret the baseline carefully:
+
+- `npm run lint` rewrites files because it runs Prettier with `--write`
+- `npm test` runs a demo/manual validation script and is not a strong assertion suite
+
+## Validation Matrix
+
+| Change type | Minimum local proof | Additional proof when risk is higher | Notes |
+| --- | --- | --- | --- |
+| `src/index*.ts` or transport init helpers | `npm run build`; `npm run lint` | run the relevant built entrypoint directly or through the intended start script when the dependency set supports it | `start:server*` currently depends on undeclared `concurrently`; record if you used a manual alternative. |
+| auth middleware, config, or OAuth flow | `npm run build`; `npm run lint` | manually inspect or run the affected built HTTP entrypoint; record any live-token proof separately | Bearer parsing, Cognito verification, and session reuse live here. |
+| search wrappers, DB CRUD wrapper, or lifecyclemodel preprocessing | `npm run build`; `npm run lint`; `npm test` | manually inspect one representative payload path or run the relevant wrapper under an MCP client if the task explicitly includes it | If the actual remote behavior changes, record the companion repo proof separately. |
+| local OpenLCA helpers | `npm run build`; `npm run lint` | run `npx tsx src/tools/openlca_ipc_test.ts` only when the task explicitly includes a local OpenLCA smoke check | The active runtime path is `olca-ipc`, not the commented gRPC scaffold. |
+| `package.json`, `.nvmrc`, `Dockerfile`, `.env.example`, or `mcp_config.json` | `npm run build`; `npm run lint` | record the runtime prerequisite or config drift that was checked | This repo currently carries a Node-version documentation mismatch. |
+| `public/**` only | `npm run build`; `npm run lint` | inspect the served page path if the task changes OAuth demo or index behavior | Static pages are part of the transport surface here. |
+| AI docs only | run the root warning-only `ai-doc-lint` against touched files | do one scenario-based routing check from root into this repo | Refresh review metadata even when prose-only docs change. |
+
+## Known Caveats
+
+Facts that matter today:
+
+- `.nvmrc` and `Dockerfile` imply Node 24
+- `DEV_EN.md` still documents Node 22
+- `start:server` and `start:server-local` use `concurrently`, but `concurrently` is not declared in `package.json`
+
+If you rely on a manual workaround, record it in the PR note instead of pretending the scripted path is clean.
+
+## Minimum PR Note Quality
+
+A good PR note for this repo should say:
+
+1. which commands ran
+2. whether any validation path was mutating or demo-only
+3. whether a manual transport, OAuth, or OpenLCA proof was performed or deferred
+4. whether any required remote runtime proof belongs in another repo


### PR DESCRIPTION
Closes linancn/tiangong-lca-mcp#14
Closes linancn/tiangong-lca-mcp#16

## Summary
- Add a checked-in AI contract layer with AGENTS.md and repo-local ai/*.md docs.
- Keep MCP transport, auth, and tool-surface boundaries explicit in the English AI layer.
- Align DEV_EN.md, DEV_CN.md, and the AI runtime notes to the checked-in Node 24 maintainer baseline.

## Validation
- npm run build
- npm run lint
- npm test
- node .github/scripts/ai-doc-lint.mjs --mode enforce --files ".github/scripts/ai-doc-lint.mjs,.github/scripts/ai-doc-lint.test.mjs,.github/workflows/ai-doc-lint.yml,AGENTS.md,DEV_CN.md,DEV_EN.md,ai/architecture.md,ai/doc-impact.yaml,ai/repo.yaml,ai/task-router.md,ai/validation.md"

## Workspace Integration
- If the merged doc change needs to ship in the workspace snapshot, bump the submodule in lca-workspace after merge.
