### PR TITLE
Upgrade docpact CI pin to 0.1.4

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: bf48b7fd4c9115350b00fddba3d302188007f2f4
+lastReviewedAt: "2026-04-24"
+lastReviewedCommit: "465ee14740515a308d5d31b5dd9879281b2f3260"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install docpact
-        run: cargo install docpact --version 0.1.2 --force
+        run: cargo install docpact --version 0.1.4 --force
 
       - name: Validate docpact config
         run: docpact validate-config --root . --strict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - src/**
   - public/**
   - test/**
-lastReviewedAt: 2026-04-18
-lastReviewedCommit: ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 465ee14740515a308d5d31b5dd9879281b2f3260
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - test/**
-lastReviewedAt: 2026-04-18
-lastReviewedCommit: ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 465ee14740515a308d5d31b5dd9879281b2f3260
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - src/**
   - public/**
   - test/**
-lastReviewedAt: 2026-04-18
-lastReviewedCommit: ec9c15dfcbb398b56b5da7e918a3a6c7ae8d1414
+lastReviewedAt: 2026-04-24
+lastReviewedCommit: 465ee14740515a308d5d31b5dd9879281b2f3260
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #19

## Summary
- Upgrade .github/workflows/ai-doc-lint.yml from docpact 0.1.2 to 0.1.4.
- Preserve the existing ai-doc-lint workflow/check name and command shape.
- Refresh governed doc review metadata required by the repo-local docpact rules for workflow changes.

## Key Decisions
- Do not change runtime code, package versions, release automation, or root workspace submodule pointers.

## Validation
- docpact validate-config --root . --strict with docpact 0.1.4.
- docpact lint --root . --worktree --mode enforce with docpact 0.1.4.
- docpact lint --root . --base origin/main --head HEAD --mode enforce with docpact 0.1.4.

## Risks / Rollback
- Root workspace integration remains pending until this child PR merges and the submodule pointer is deliberately bumped.

## Workspace Integration
- Part of tiangong-lca/workspace#77; child issue keeps Workspace Integration Pending.