### PR TITLE
docs: hide README metadata from public landing page

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -235,13 +235,9 @@ rules:
         kind: repo-landing
     requiredDocs:
       - path: AGENTS.md
-        mode: review_or_update
-      - path: README.md
-        mode: review_or_update
-      - path: README_CN.md
-        mode: review_or_update
+        mode: must_exist
       - path: .docpact/config.yaml
-        mode: review_or_update
+        mode: must_exist
     reason: User-facing MCP setup docs should stay aligned with the current public package and runtime surface.
   - id: mcp-maintainer-docs-contract
     scope: repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,8 +30,8 @@ checkPaths:
   - src/**
   - public/**
   - test/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 465ee14740515a308d5d31b5dd9879281b2f3260
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: b9ebb102bb05127412cfe8a91020cdcb26660460
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/README.md
+++ b/README.md
@@ -1,33 +1,3 @@
----
-title: TianGong LCA MCP README
-docType: guide
-scope: repo
-status: active
-authoritative: false
-owner: mcp
-language: en
-whenToUse:
-  - when you need user-facing MCP package setup, Docker usage, local startup, or inspector examples
-whenToUpdate:
-  - when public startup commands, Docker usage, package invocation, or user-facing MCP examples change
-checkPaths:
-  - README.md
-  - README_CN.md
-  - package.json
-  - Dockerfile
-  - mcp_config.json
-  - src/index.ts
-  - src/index_server.ts
-  - src/index_server_local.ts
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: bf48b7fd4c9115350b00fddba3d302188007f2f4
-related:
-  - AGENTS.md
-  - .docpact/config.yaml
-  - DEV_EN.md
-  - README_CN.md
----
-
 # TianGong-LCA-MCP
 
 [中文](https://github.com/linancn/tiangong-lca-mcp/blob/main/README_CN.md) | [English](https://github.com/linancn/tiangong-lca-mcp/blob/main/README.md)

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -21,8 +21,8 @@ checkPaths:
   - src/**
   - public/**
   - test/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 465ee14740515a308d5d31b5dd9879281b2f3260
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: b9ebb102bb05127412cfe8a91020cdcb26660460
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -25,8 +25,8 @@ checkPaths:
   - src/**
   - public/**
   - test/**
-lastReviewedAt: 2026-04-24
-lastReviewedCommit: 465ee14740515a308d5d31b5dd9879281b2f3260
+lastReviewedAt: 2026-05-06
+lastReviewedCommit: b9ebb102bb05127412cfe8a91020cdcb26660460
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
Closes #21

## Summary
- Remove visible YAML front matter from the root README so GitHub renders the public landing page from the heading.
- Adjust the README landing docpact rule to keep README changes covered without requiring README.md to carry governance metadata.
- Refresh review metadata on the repo entry/governance docs required by the docpact rule change.

## Key Decisions
- README landing rules now use must_exist checks for AGENTS.md and .docpact/config.yaml instead of review_or_update on README.md.

## Validation
- docpact validate-config --strict
- docpact lint --merge-base <target-base> --mode enforce

## Risks / Rollback
- Low-risk docs/governance change; rollback is restoring the prior README front matter and rule modes.

## Workspace Integration
- After merge, lca-workspace should bump the submodule pointer for this repo.