### PR TITLE
chore: release mcp 0.0.30

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-25"
-lastReviewedCommit: "b30b65f06723246379152687a05e2cd1992f9cae"
+lastReviewedCommit: "a782303fab7bba4dc53bfe53b8d00e7e5f07221c"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: b30b65f06723246379152687a05e2cd1992f9cae
+lastReviewedCommit: a782303fab7bba4dc53bfe53b8d00e7e5f07221c
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -109,11 +109,11 @@ npx tsx src/tools/openlca_ipc_test.ts
 ### 发布
 
 ```bash
-docker build --no-cache -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.6 .
+docker build --no-cache -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30 .
 
 aws ecr get-login-password --region us-east-1  | docker login --username AWS --password-stdin 339712838008.dkr.ecr.us-east-1.amazonaws.com
 
-docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.6
+docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30
 
-docker run -d -p 9278:9278 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.6
+docker run -d -p 9278:9278 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30
 ```

--- a/DEV_EN.md
+++ b/DEV_EN.md
@@ -116,11 +116,11 @@ npx tsx src/tools/openlca_ipc_test.ts
 ### Deployment
 
 ```bash
-docker build --no-cache -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.6 .
+docker build --no-cache -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30 .
 
 aws ecr get-login-password --region us-east-1  | docker login --username AWS --password-stdin 339712838008.dkr.ecr.us-east-1.amazonaws.com
 
-docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.6
+docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30
 
-docker run -d -p 9278:9278 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.6
+docker run -d -p 9278:9278 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine
 
-RUN npm install -g @tiangong-lca/mcp-server@0.0.29
+RUN npm install -g @tiangong-lca/mcp-server@0.0.30
 
 EXPOSE 80
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 14972c496eff14cd536b9ab5016145d2c0d57c14
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: a782303fab7bba4dc53bfe53b8d00e7e5f07221c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -29,8 +29,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-08
-lastReviewedCommit: 14972c496eff14cd536b9ab5016145d2c0d57c14
+lastReviewedAt: 2026-05-25
+lastReviewedCommit: a782303fab7bba4dc53bfe53b8d00e7e5f07221c
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/mcp-server",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/mcp-server",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tiangong-lca/mcp-server",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "TianGong LCA MCP Server",
   "license": "MIT",
   "author": "Nan LI",


### PR DESCRIPTION
## Summary
- Bump @tiangong-lca/mcp-server to 0.0.30 for the GLAD tool release.
- Update the Dockerfile to install @tiangong-lca/mcp-server@0.0.30.
- Update deployment docs to use the 0.0.30 ECR tag.

## Validation
- npm run build
- npm run lint
- npm test
- ../scripts/docpact lint --root . --worktree --mode enforce

## Follow-up
After merge, push tag v0.0.30 to trigger trusted npm publishing, then build and deploy the ECR/ECS release.