### PR TITLE
chore: release mcp 0.0.31

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-25"
-lastReviewedCommit: "a782303fab7bba4dc53bfe53b8d00e7e5f07221c"
+lastReviewedCommit: "e8e4b0762abe8a31723c73724e98c14d75c931a5"
 
 catalog:
   repos:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: a782303fab7bba4dc53bfe53b8d00e7e5f07221c
+lastReviewedCommit: e8e4b0762abe8a31723c73724e98c14d75c931a5
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/DEV_CN.md
+++ b/DEV_CN.md
@@ -19,7 +19,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: b30b65f06723246379152687a05e2cd1992f9cae
+lastReviewedCommit: e8e4b0762abe8a31723c73724e98c14d75c931a5
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -98,7 +98,7 @@ npm version patch
 git push origin main --follow-tags
 ```
 
-发布由 GitHub Actions trusted publishing 执行。Tag 继续使用本单包仓库的 `v<package.version>` 格式；例如 package 版本 `0.0.30` 对应发布 tag `v0.0.30`。
+发布由 GitHub Actions trusted publishing 执行。Tag 继续使用本单包仓库的 `v<package.version>` 格式；例如 package 版本 `0.0.31` 对应发布 tag `v0.0.31`。
 
 ### 测试脚手架
 
@@ -109,11 +109,11 @@ npx tsx src/tools/openlca_ipc_test.ts
 ### 发布
 
 ```bash
-docker build --no-cache -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30 .
+docker build --no-cache -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.31 .
 
 aws ecr get-login-password --region us-east-1  | docker login --username AWS --password-stdin 339712838008.dkr.ecr.us-east-1.amazonaws.com
 
-docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30
+docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.31
 
-docker run -d -p 9278:9278 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30
+docker run -d -p 9278:9278 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.31
 ```

--- a/DEV_EN.md
+++ b/DEV_EN.md
@@ -19,7 +19,7 @@ checkPaths:
   - src/**
   - test/**
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: b30b65f06723246379152687a05e2cd1992f9cae
+lastReviewedCommit: e8e4b0762abe8a31723c73724e98c14d75c931a5
 related:
   - AGENTS.md
   - .docpact/config.yaml
@@ -105,7 +105,7 @@ npm version patch
 git push origin main --follow-tags
 ```
 
-Publishing is handled by GitHub Actions trusted publishing. Tags must keep the existing single-package format `v<package.version>`; for example, package version `0.0.30` must be released from tag `v0.0.30`.
+Publishing is handled by GitHub Actions trusted publishing. Tags must keep the existing single-package format `v<package.version>`; for example, package version `0.0.31` must be released from tag `v0.0.31`.
 
 ### scaffold
 
@@ -116,11 +116,11 @@ npx tsx src/tools/openlca_ipc_test.ts
 ### Deployment
 
 ```bash
-docker build --no-cache -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30 .
+docker build --no-cache -t 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.31 .
 
 aws ecr get-login-password --region us-east-1  | docker login --username AWS --password-stdin 339712838008.dkr.ecr.us-east-1.amazonaws.com
 
-docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30
+docker push 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.31
 
-docker run -d -p 9278:9278 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.30
+docker run -d -p 9278:9278 --env-file .env 339712838008.dkr.ecr.us-east-1.amazonaws.com/tiangong-lca-mcp:0.0.31
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:24-alpine
 
-RUN npm install -g @tiangong-lca/mcp-server@0.0.30
+RUN npm install -g @tiangong-lca/mcp-server@0.0.31
 
 EXPOSE 80
 

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: a782303fab7bba4dc53bfe53b8d00e7e5f07221c
+lastReviewedCommit: e8e4b0762abe8a31723c73724e98c14d75c931a5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-25
-lastReviewedCommit: a782303fab7bba4dc53bfe53b8d00e7e5f07221c
+lastReviewedCommit: e8e4b0762abe8a31723c73724e98c14d75c931a5
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tiangong-lca/mcp-server",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tiangong-lca/mcp-server",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@tiangong-lca/mcp-server",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "TianGong LCA MCP Server",
   "license": "MIT",
   "author": "Nan LI",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/linancn/tiangong-lca-mcp"
+  },
   "type": "module",
   "bin": {
     "tiangong-lca-mcp-stdio": "dist/src/index.js",


### PR DESCRIPTION
## Summary
- bump MCP package and Docker release references to 0.0.31
- add package repository metadata required by npm provenance trusted publishing
- refresh docpact review evidence for runtime/publish docs

## Validation
- npm run build
- npm run lint
- npm test
- ../scripts/docpact lint --root . --worktree --mode enforce

## Release notes
- Replaces the failed v0.0.30 publish attempt; v0.0.30 was not published to npm.
