### PR TITLE
chore: gate mcp npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,30 @@ permissions:
   contents: read
 
 jobs:
+  release-gate:
+    name: Release Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run full pre-publish gate
+        run: npm run prepush:gate
+
   npm-publish:
     name: Publish npm package
+    needs: release-gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,9 +63,7 @@ jobs:
         run: node ./scripts/ci/release-version.cjs assert-unpublished
 
       - name: Verify package
-        run: |
-          npm run prepush:gate
-          npm pack --dry-run >/dev/null
+        run: npm pack --dry-run >/dev/null
 
       - name: Publish to npm
         run: npm publish --access public --provenance


### PR DESCRIPTION
Closes linancn/tiangong-lca-mcp#31

## Summary
- Add release-gate before npm package publish.
- Run npm prepush gate before v* tag publish.

## Key Decisions
- Keep ordinary pushes free of standalone remote test gates; npm publish owns release validation.

## Validation
- docpact gate passed during push.
- YAML parse, shell syntax, and staged diff checks passed locally before commit.

## Risks / Rollback
- Publish now waits for the package prepush gate before npm release.

## Workspace Integration
- Requires lca-workspace submodule pointer update after merge.