### PR TITLE
fix: build package before publish pack

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Check npm registry version availability
         run: node ./scripts/ci/release-version.cjs assert-unpublished
 
+      - name: Build package artifacts
+        run: npm run build
+
       - name: Verify package
         run: npm pack --dry-run >/dev/null
 


### PR DESCRIPTION
## Summary
- Rebuild npm package artifacts in the isolated npm-publish job before pack and publish.
- Keep the release-gate job as the full pre-publish gate while ensuring the publish workspace contains dist.

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/publish.yml')"
- npm run build && npm pack --dry-run >/dev/null
- scripts/docpact lint --root . --staged --format text
- push hook: docpact gate

Closes #33