### PR TITLE
Fix docpact gate review feedback

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "fc36076a73d32291a0daf0ceb5575dc42b8fb305"
+lastReviewedCommit: "8471054534129acbcb316bd5e53b394c586cd8b4"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "e75836375f6055a09730d12c4b1ba2d575b4d79d"
+lastReviewedCommit: "0771ac4dd5f618a43c5e496005e3cfdd2f3ad461"
 
 catalog:
   repos:

--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
 lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "0771ac4dd5f618a43c5e496005e3cfdd2f3ad461"
+lastReviewedCommit: "fc36076a73d32291a0daf0ceb5575dc42b8fb305"
 
 catalog:
   repos:

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -31,4 +31,6 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"
+        env:
+          BASE_REF: ${{ inputs.base_ref }}
+        run: scripts/docpact-gate.sh --base "$BASE_REF"

--- a/.github/workflows/ai-doc-lint.yml
+++ b/.github/workflows/ai-doc-lint.yml
@@ -2,6 +2,11 @@ name: ai-doc-lint
 
 on:
   workflow_dispatch:
+    inputs:
+      base_ref:
+        description: Base ref for the manual docpact comparison.
+        required: false
+        default: origin/main
 
 permissions:
   contents: read
@@ -16,8 +21,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Fetch main
-        run: git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+      - name: Fetch branches
+        run: git fetch --force origin '+refs/heads/*:refs/remotes/origin/*'
 
       - name: Install stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -26,4 +31,4 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run local docpact gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: scripts/docpact-gate.sh --base "${{ inputs.base_ref }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,11 @@ jobs:
         run: cargo install docpact --version 0.1.9 --force
 
       - name: Run docpact release gate
-        run: scripts/docpact-gate.sh --base origin/main
+        run: |
+          set -euo pipefail
+          release_head="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
+          release_base="$(git rev-parse "${release_head}^")"
+          scripts/docpact-gate.sh --base "$release_base" --head "$release_head"
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: e8e4b0762abe8a31723c73724e98c14d75c931a5
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: 0771ac4dd5f618a43c5e496005e3cfdd2f3ad461
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: fc36076a73d32291a0daf0ceb5575dc42b8fb305
+lastReviewedCommit: 8471054534129acbcb316bd5e53b394c586cd8b4
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 0771ac4dd5f618a43c5e496005e3cfdd2f3ad461
+lastReviewedCommit: fc36076a73d32291a0daf0ceb5575dc42b8fb305
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -25,8 +25,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-25
-lastReviewedCommit: e8e4b0762abe8a31723c73724e98c14d75c931a5
+lastReviewedAt: 2026-05-28
+lastReviewedCommit: fc36076a73d32291a0daf0ceb5575dc42b8fb305
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -26,7 +26,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: fc36076a73d32291a0daf0ceb5575dc42b8fb305
+lastReviewedCommit: 8471054534129acbcb316bd5e53b394c586cd8b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: fc36076a73d32291a0daf0ceb5575dc42b8fb305
+lastReviewedCommit: 8471054534129acbcb316bd5e53b394c586cd8b4
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: e75836375f6055a09730d12c4b1ba2d575b4d79d
+lastReviewedCommit: 0771ac4dd5f618a43c5e496005e3cfdd2f3ad461
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -30,7 +30,7 @@ checkPaths:
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
 lastReviewedAt: 2026-05-28
-lastReviewedCommit: 0771ac4dd5f618a43c5e496005e3cfdd2f3ad461
+lastReviewedCommit: fc36076a73d32291a0daf0ceb5575dc42b8fb305
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml


### PR DESCRIPTION
## Summary
- address Codex review feedback from the ai-doc local-gate rollout
- make manual ai-doc/docpact fallback workflows accept an explicit base_ref and fetch remote branches
- make release tag docpact gates compare the tag commit against its parent instead of a base that can collapse to the tag commit
- refresh governance review evidence for the touched workflow guidance docs

## Validation
- YAML workflow parse passed from the workspace root
- local docpact/ai-doc gate passed for this branch

Refs tiangong-lca/workspace#183