### PR TITLE
chore: automate mcp releases

### DIFF
--- a/.docpact/config.yaml
+++ b/.docpact/config.yaml
@@ -1,7 +1,7 @@
 version: 1
 layout: repo
-lastReviewedAt: "2026-05-28"
-lastReviewedCommit: "8471054534129acbcb316bd5e53b394c586cd8b4"
+lastReviewedAt: "2026-06-01"
+lastReviewedCommit: "afbb47af17b81da4cd4bad31a8e13c498612c4cd"
 
 catalog:
   repos:
@@ -29,6 +29,12 @@ ownership:
           - .docpact/config.yaml
           - docs/agents/**
           - .github/workflows/ai-doc-lint.yml
+      ownerRepo: mcp
+    - id: validation-release-and-automation
+      paths:
+        include:
+          - scripts/ci/**
+          - .github/workflows/publish.yml
       ownerRepo: mcp
     - id: runtime-and-package-config
       paths:
@@ -87,6 +93,7 @@ coverage:
     - DEV_CN.md
     - .docpact/config.yaml
     - docs/agents/**
+    - scripts/ci/**
     - package.json
     - tsconfig.json
     - .nvmrc
@@ -98,6 +105,7 @@ coverage:
     - public/**
     - src/**
     - test/**
+    - .github/workflows/publish.yml
     - .github/workflows/ai-doc-lint.yml
   exclude:
     - .git/**
@@ -178,6 +186,8 @@ routing:
     validation-runtime:
       paths:
         - package.json
+        - scripts/ci/**
+        - .github/workflows/publish.yml
         - tsconfig.json
         - .nvmrc
         - .prettierrc.cjs
@@ -189,6 +199,8 @@ routing:
       paths:
         - docs/agents/repo-validation.md
         - package.json
+        - scripts/ci/**
+        - .github/workflows/publish.yml
         - tsconfig.json
         - src/**
         - public/**
@@ -202,6 +214,8 @@ routing:
         - DEV_CN.md
         - .docpact/config.yaml
         - docs/agents/**
+        - scripts/ci/**
+        - .github/workflows/publish.yml
     root-integration:
       paths:
         - AGENTS.md
@@ -322,6 +336,24 @@ rules:
       - path: DEV_EN.md
         mode: review_or_update
     reason: Transport, auth, OAuth, and runtime prerequisite changes alter the executable MCP contract.
+  - id: mcp-validation-and-release-contract
+    scope: repo
+    repo: mcp
+    triggers:
+      - path: scripts/ci/**
+        kind: release-script
+      - path: .github/workflows/publish.yml
+        kind: release-automation
+    requiredDocs:
+      - path: AGENTS.md
+        mode: review_or_update
+      - path: .docpact/config.yaml
+        mode: review_or_update
+      - path: docs/agents/repo-validation.md
+        mode: review_or_update
+      - path: docs/agents/repo-architecture.md
+        mode: review_or_update
+    reason: Release scripts and publish workflow changes alter package validation, tag gating, and npm publish behavior without changing transport/auth startup docs.
   - id: mcp-tool-contract
     scope: repo
     repo: mcp

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,22 +1,187 @@
 name: Publish Package
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Existing v* tag to release with the current workflow definition.
+        required: true
+        type: string
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
 permissions:
-  contents: read
+  contents: write
+
+concurrency:
+  group: mcp-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  release-context:
+    name: Release Context
+    runs-on: ubuntu-latest
+    outputs:
+      release_base: ${{ steps.release.outputs.release_base }}
+      release_head: ${{ steps.release.outputs.release_head }}
+      should_release: ${{ steps.release.outputs.should_release }}
+      tag_created: ${{ steps.release.outputs.tag_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Resolve release target
+        id: release
+        env:
+          PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
+          REQUESTED_TAG_NAME: ${{ github.event.inputs.tag_name || '' }}
+        run: |
+          set -euo pipefail
+
+          git fetch --force origin +refs/heads/main:refs/remotes/origin/main
+          git fetch --force origin '+refs/tags/*:refs/tags/*'
+
+          if [ "${GITHUB_REPOSITORY}" != "linancn/tiangong-lca-mcp" ]; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "tag_created=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping release outside canonical repository: ${GITHUB_REPOSITORY}."
+            exit 0
+          fi
+
+          read_package_version() {
+            git show "${1}:package.json" | node -e "const fs = require('fs'); const pkg = JSON.parse(fs.readFileSync(0, 'utf8')); console.log(pkg.version);"
+          }
+
+          tag_created=false
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            tag_name="${REQUESTED_TAG_NAME}"
+            if [ -z "${tag_name}" ] || [[ "${tag_name}" != v* ]]; then
+              echo "::error::workflow_dispatch tag_name must be an existing v* tag."
+              exit 1
+            fi
+
+            if ! release_head="$(git rev-list -n 1 "${tag_name}" 2>/dev/null)"; then
+              echo "::error::Release tag ${tag_name} does not exist."
+              exit 1
+            fi
+
+            package_version="$(read_package_version "${release_head}")"
+            expected_tag="v${package_version}"
+            if [ "${tag_name}" != "${expected_tag}" ]; then
+              echo "::error::Release tag ${tag_name} does not match package.json version ${package_version} at ${release_head}."
+              exit 1
+            fi
+
+            echo "::notice::Releasing existing ${tag_name} at ${release_head} with the current workflow definition."
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            tag_name="${GITHUB_REF_NAME}"
+            release_head="$(git rev-list -n 1 "${tag_name}")"
+            package_version="$(read_package_version "${release_head}")"
+            expected_tag="v${package_version}"
+            if [ "${tag_name}" != "${expected_tag}" ]; then
+              echo "::error::Release tag ${tag_name} does not match package.json version ${package_version} at ${release_head}."
+              exit 1
+            fi
+          else
+            release_head="${GITHUB_SHA}"
+            package_version="$(read_package_version "${release_head}")"
+            tag_name="v${package_version}"
+            version_changed=false
+
+            if [ -n "${PUSH_BEFORE_SHA}" ] && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ]; then
+              if git cat-file -e "${PUSH_BEFORE_SHA}:package.json" 2>/dev/null; then
+                previous_version="$(read_package_version "${PUSH_BEFORE_SHA}")"
+                if [ "${previous_version}" != "${package_version}" ]; then
+                  version_changed=true
+                fi
+              fi
+            fi
+
+            existing_tag_sha="$(git ls-remote --tags origin "refs/tags/${tag_name}" | awk '{print $1}')"
+            if [ -n "${existing_tag_sha}" ]; then
+              git fetch --force origin "refs/tags/${tag_name}:refs/tags/${tag_name}"
+              existing_tag_commit="$(git rev-list -n 1 "${tag_name}")"
+              if [ "${existing_tag_commit}" != "${release_head}" ]; then
+                if [ "${version_changed}" = "false" ]; then
+                  echo "should_release=false" >> "$GITHUB_OUTPUT"
+                  echo "tag_created=false" >> "$GITHUB_OUTPUT"
+                  echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+                  echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+                  echo "::notice::${tag_name} already points to ${existing_tag_commit}; package.json version was unchanged in this main push, so this is not a new release."
+                  exit 0
+                fi
+
+                echo "::error::${tag_name} already points to ${existing_tag_commit}, not current main commit ${release_head}. Bump package.json before releasing another main commit."
+                exit 1
+              fi
+              echo "::notice::${tag_name} already exists on current main commit ${release_head}; continuing release."
+            else
+              if [ "${version_changed}" != "true" ]; then
+                echo "should_release=false" >> "$GITHUB_OUTPUT"
+                echo "tag_created=false" >> "$GITHUB_OUTPUT"
+                echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+                echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+                echo "::notice::package.json version did not change in this main push; skipping release."
+                exit 0
+              fi
+
+              git tag "${tag_name}" "${release_head}"
+              git push origin "refs/tags/${tag_name}"
+              tag_created=true
+              echo "::notice::Created ${tag_name} on ${release_head}."
+            fi
+          fi
+
+          if ! git merge-base --is-ancestor "${release_head}" origin/main; then
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+            echo "tag_created=${tag_created}" >> "$GITHUB_OUTPUT"
+            echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+            echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release target ${tag_name} points to ${release_head}, which is not on origin/main. Skipping npm publish."
+            exit 0
+          fi
+
+          release_base="$(git rev-parse "${release_head}^")"
+
+          echo "release_base=${release_base}" >> "$GITHUB_OUTPUT"
+          echo "release_head=${release_head}" >> "$GITHUB_OUTPUT"
+          echo "should_release=true" >> "$GITHUB_OUTPUT"
+          echo "tag_created=${tag_created}" >> "$GITHUB_OUTPUT"
+          echo "tag_name=${tag_name}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Release context"
+            echo "- tag: \`${tag_name}\`"
+            echo "- head: \`${release_head}\`"
+            echo "- base: \`${release_base}\`"
+            echo "- package version: \`${package_version}\`"
+            echo "- tag created: \`${tag_created}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   release-gate:
     name: Release Gate
+    needs: release-context
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ needs.release-context.outputs.release_head }}
           fetch-depth: 0
 
       - name: Fetch main
@@ -31,8 +196,8 @@ jobs:
       - name: Run docpact release gate
         run: |
           set -euo pipefail
-          release_head="$(git rev-list -n 1 "$GITHUB_REF_NAME")"
-          release_base="$(git rev-parse "${release_head}^")"
+          release_head="${{ needs.release-context.outputs.release_head }}"
+          release_base="${{ needs.release-context.outputs.release_base }}"
           scripts/docpact-gate.sh --base "$release_base" --head "$release_head"
 
       - name: Set up Node.js
@@ -50,7 +215,10 @@ jobs:
 
   npm-publish:
     name: Publish npm package
-    needs: release-gate
+    needs:
+      - release-context
+      - release-gate
+    if: needs.release-context.outputs.should_release == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -59,6 +227,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.release-context.outputs.release_head }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -75,7 +245,7 @@ jobs:
         run: npm ci
 
       - name: Validate release tag
-        run: node ./scripts/ci/check-release-tag.cjs mcp
+        run: node ./scripts/ci/check-release-tag.cjs mcp "${{ needs.release-context.outputs.tag_name }}"
 
       - name: Check npm registry version availability
         run: node ./scripts/ci/release-version.cjs assert-unpublished

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,12 +30,14 @@ checkPaths:
   - src/**
   - public/**
   - test/**
+  - scripts/ci/**
+  - .github/workflows/publish.yml
   - .githooks/**
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 8471054534129acbcb316bd5e53b394c586cd8b4
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: afbb47af17b81da4cd4bad31a8e13c498612c4cd
 related:
   - .docpact/config.yaml
   - docs/agents/repo-validation.md
@@ -103,6 +105,8 @@ Route those tasks to:
   - `tiangong-lca-mcp-stdio`
   - `tiangong-lca-mcp-http`
   - `tiangong-lca-mcp-http-local`
+- Release tags use `v<package.json version>`; canonical `main` branch pushes whose package version changes create the matching tag when missing, run the release gate, and publish `@tiangong-lca/mcp-server` to npm in the same workflow run
+- Manual `v*` tag pushes and `workflow_dispatch` runs for an existing release tag whose target commit is already on `main` remain supported for recovery/backfill releases
 - The checked-in runtime prerequisites are currently inconsistent:
   - `.nvmrc` and `Dockerfile` imply Node 24
   - `DEV_EN.md` still says Node 22

--- a/docs/agents/repo-architecture.md
+++ b/docs/agents/repo-architecture.md
@@ -18,6 +18,8 @@ checkPaths:
   - docs/agents/repo-architecture.md
   - .docpact/config.yaml
   - package.json
+  - scripts/ci/**
+  - .github/workflows/publish.yml
   - src/**
   - public/**
   - test/**
@@ -25,8 +27,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 8471054534129acbcb316bd5e53b394c586cd8b4
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: afbb47af17b81da4cd4bad31a8e13c498612c4cd
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -122,6 +124,10 @@ The active local OpenLCA integration uses `olca-ipc`. The `openlca_grpc.ts` file
 - `next` owns product UI behavior
 - `tidas-tools` owns standalone conversion, export, and batch validation tooling
 - this repo owns MCP transports, auth classification, and tool exposure
+
+## Release Architecture
+
+`main` pushes whose `package.json` version changes create the matching `v<version>` tag, run the release gate, and publish `@tiangong-lca/mcp-server` to npm. Manual `v*` tag pushes and workflow-dispatch runs for existing tags remain recovery/backfill paths.
 
 ## Common Misreads
 

--- a/docs/agents/repo-validation.md
+++ b/docs/agents/repo-validation.md
@@ -22,6 +22,8 @@ checkPaths:
   - Dockerfile
   - .env.example
   - mcp_config.json
+  - scripts/ci/**
+  - .github/workflows/publish.yml
   - src/**
   - public/**
   - test/**
@@ -29,8 +31,8 @@ checkPaths:
   - scripts/docpact
   - scripts/docpact-gate.sh
   - scripts/install-git-hooks.sh
-lastReviewedAt: 2026-05-28
-lastReviewedCommit: 8471054534129acbcb316bd5e53b394c586cd8b4
+lastReviewedAt: 2026-06-01
+lastReviewedCommit: afbb47af17b81da4cd4bad31a8e13c498612c4cd
 related:
   - ../../AGENTS.md
   - ../../.docpact/config.yaml
@@ -65,6 +67,7 @@ Interpret the baseline carefully:
 | search wrappers, GLAD dataset tools, DB CRUD wrapper, or lifecyclemodel preprocessing | `npm run build`; `npm run lint`; `npm test` | manually inspect one representative payload path or run the relevant wrapper under an MCP client if the task explicitly includes it | If the actual remote behavior changes, record the companion repo proof separately. GLAD API validation may need a browser-verified or otherwise allowed runtime because Cloudflare can challenge raw Node/curl requests before the API key is processed. |
 | local OpenLCA helpers | `npm run build`; `npm run lint` | run `npx tsx src/tools/openlca_ipc_test.ts` only when the task explicitly includes a local OpenLCA smoke check | The active runtime path is `olca-ipc`, not the commented gRPC scaffold. |
 | `package.json`, `.nvmrc`, `Dockerfile`, `.env.example`, or `mcp_config.json` | `npm run build`; `npm run lint` | record the runtime prerequisite or config drift that was checked | Recheck `DEV_EN.md` and `DEV_CN.md` whenever the Node baseline or maintainer startup path changes. |
+| release automation under `scripts/ci/**` or `.github/workflows/publish.yml` | inspect the workflow/script diff; run `npm run build` when package metadata or release scripts execute package code | record tag naming, `main`-only release, and npm unpublished-version assumptions checked locally | Release publish runs the full pre-publish gate before npm publish. |
 | `public/**` only | `npm run build`; `npm run lint` | inspect the served page path if the task changes OAuth demo or index behavior | Static pages are part of the transport surface here. |
 | governed docs only | `scripts/docpact validate-config --root . --strict`; `scripts/docpact lint --root . --staged --mode enforce` | run one focused route check such as `transport-auth`, `mcp-tools`, or `openlca-tidas` when routing changes | Refresh review metadata even when prose-only docs change. |
 


### PR DESCRIPTION
Closes #39

## Summary
- Add release-context handling so main pushes that change package.json.version create the matching v* tag and publish to npm.
- Keep tag push and workflow_dispatch paths for recovery/backfill releases.

## Key Decisions
- Split release automation docpact routing away from transport/auth runtime docs.
- Pass the resolved release tag explicitly to the release-tag validator.

## Validation
- git diff --check
- scripts/docpact validate-config --root . --strict
- scripts/docpact lint --root . --merge-base origin/main --mode enforce --format json
- Ruby YAML parse for .github/workflows/publish.yml
- node ./scripts/ci/check-release-tag.cjs mcp v0.0.31

## Risks / Rollback
- Low operational risk: npm publish still requires release gate success and unpublished-version validation.

## Follow-ups
- Monitor the first package version bump release after merge.

## Workspace Integration
- Requires later lca-workspace submodule pointer update after merge/release eligibility.